### PR TITLE
Update HttpWebHookPushButtonAccessory.js

### DIFF
--- a/src/homekit/accessories/HttpWebHookPushButtonAccessory.js
+++ b/src/homekit/accessories/HttpWebHookPushButtonAccessory.js
@@ -52,7 +52,7 @@ HttpWebHookPushButtonAccessory.prototype.changeFromServer = function(urlParams) 
 }
 
 HttpWebHookPushButtonAccessory.prototype.getState = function(callback) {
-  this.log("Getting current state for '%s'...", this.id);
+  this.log.debug("Getting current state for '%s'...", this.id);
   var state = false;
   callback(null, state);
 };


### PR DESCRIPTION
Moved logging for getState to debug level to prevent flooding of homebridge logs